### PR TITLE
If the user puts in an id of an existing note/uri, then populate thos…

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -153,7 +153,6 @@ app.get('/:id/content', async (req, res) => {
     try {
         if (await storage.has(rid)) {
             const record = await storage.get(rid);
-            let content = {};
             if (record.isNote()) {
                 res.send({
                     type: 'note',

--- a/src/main.js
+++ b/src/main.js
@@ -146,6 +146,36 @@ app.get('/:id/raw', async (req, res) => {
     }
 });
 
+app.get('/:id/content', async (req, res) => {
+    res.set('Content-Type', 'application/json');
+
+    const rid = req.params.id;
+    try {
+        if (await storage.has(rid)) {
+            const record = await storage.get(rid);
+            let content = {};
+            if (record.isNote()) {
+                res.send({
+                    type: 'note',
+                    content: record.getRawNote(),
+                });
+            } else if (record.isURI()) {
+                res.send({
+                    type: 'uri',
+                    content: record.getRedirect(),
+                });
+            }
+        } else {
+            res.send({
+                type: 'none',
+                content: `Record ${rid} does not exist.`
+            });
+        }
+    } catch (e) {
+        console.error(e);
+    }
+});
+
 app.get('/:id/locked', async (req, res) => {
     res.set('Content-Type', 'text/plain');
 

--- a/static/index.html
+++ b/static/index.html
@@ -105,7 +105,7 @@
                       }
 
                       if (userTypedInput) {
-                          let replace = confirm(`Do you want to replace what you've typed with the existing content for id ${id}?`);
+                          const replace = confirm(`Do you want to replace what you've typed with the existing content for id ${id}?`);
                           if (!replace) {
                               return;
                           }
@@ -137,15 +137,18 @@
 
           setPasswordGroupVisibility(false);
           idInput.addEventListener('input', debounce(async () => {
-              const showPasswordRequired = await checkIfShouldShowPasswordRequired();
+              const [showPasswordRequired, _] = [
+                  await checkIfShouldShowPasswordRequired(),
+                  await populateContentForExistingNote(),
+              ];
               setPasswordGroupVisibility(showPasswordRequired);
               await populateContentForExistingNote();
           }, 400));
           uriInput.addEventListener('input', () => {
-              userTypedInput = true;
+              userTypedInput = uriInput.value.length > 0;
           });
           noteInput.addEventListener('input', () => {
-              userTypedInput = true;
+              userTypedInput = noteInput.value.length > 0;
           });
       })();
   </script>

--- a/static/index.html
+++ b/static/index.html
@@ -68,6 +68,10 @@
       (function() {
           const idInput = document.querySelector('input[id="id"]');
           const requiredMessage = document.querySelector('.requiredMessage');
+          const uriInput = document.querySelector('input[id="content_uri"]');
+          const noteInput = document.querySelector('textarea[id="content_note"]');
+
+          let userTypedInput = false;
 
           function setPasswordGroupVisibility(displayed) {
               requiredMessage.style.display = displayed ? '' : 'none';
@@ -87,6 +91,41 @@
                   return false;
               }
           }
+          async function populateContentForExistingNote() {
+              const id = idInput.value;
+              if (id) {
+                  try {
+                      const content = await fetch(`/${id}/content`).then(resp => resp.json());
+                      if (content['type'] == "none") {
+                          if (!userTypedInput) {
+                              uriInput.value = "";
+                              noteInput.value = "";
+                          }
+                          return;
+                      }
+
+                      if (userTypedInput) {
+                          let replace = confirm(`Do you want to replace what you've typed with the existing content for id ${id}?`);
+                          if (!replace) {
+                              return;
+                          }
+                      }
+
+                      if (content['type'] == "note") {
+                          uriInput.value = "";
+                          noteInput.value = content['content'];
+                      }
+                      else if (content['type'] == "uri") {
+                          uriInput.value = content['content'];
+                          noteInput.value = '';
+                      }
+
+                      userTypedInput = false;
+
+                  } catch (e) {
+                  }
+              }
+          }
 
           function debounce(fn, duration) {
               let timeout = undefined;
@@ -100,7 +139,14 @@
           idInput.addEventListener('input', debounce(async () => {
               const showPasswordRequired = await checkIfShouldShowPasswordRequired();
               setPasswordGroupVisibility(showPasswordRequired);
+              await populateContentForExistingNote();
           }, 400));
+          uriInput.addEventListener('input', () => {
+              userTypedInput = true;
+          });
+          noteInput.addEventListener('input', () => {
+              userTypedInput = true;
+          });
       })();
   </script>
 </body>


### PR DESCRIPTION
…e inputs with the existing content.

Relies on new /:id/content/ endpoint, which returns json which includes the content and type of the record.
If the user has already typed in either of the fields, they are prompted (using the ugly standard `confirm` popup) as to whether they would like to replace their work with the existing content