### PR TITLE
Sanitize potentially dangerous HTML in markdown notes

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -3,7 +3,11 @@ const path = require('path');
 const crypto = require('crypto');
 
 const marked = require('marked');
-const { randid, validid } = require('./utils.js');
+const {
+    randid,
+    validid,
+    sanitizeDangerousHtml,
+} = require('./utils.js');
 
 class StorageBackend {
 
@@ -77,7 +81,7 @@ class Record {
         this.id = id.trim();
         this.type = type;
         this.hash = hash || (password ? Record.hash(this.id, password) : undefined);
-        this.content = content.trim();
+        this.content = sanitizeDangerousHtml(content.trim());
     }
 
     isLocked() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,8 +19,56 @@ const validid = id => {
     );
 }
 
+const DANGEROUS_HTML_TAGS = [
+    'head',
+    'body',
+    'title',
+    'link',
+    'style',
+    'script',
+];
+
+const sanitizeDangerousHtml = markdownString => {
+    let result = '';
+    let inOpeningTag = false;
+    let lastTag = '';
+
+    for (let i = 0; i < markdownString.length; i ++) {
+        const char = markdownString[i];
+
+        if (char === '<') {
+            inOpeningTag = true;
+        } else if ((char === '>' || char.trim() == '') && inOpeningTag) {
+            inOpeningTag = false;
+            if (DANGEROUS_HTML_TAGS.includes(lastTag.trim().toLowerCase())) {
+                // read and ignore until the tag is closed
+                const closingTag = `</${lastTag}>`;
+                const indexOfClosingTag = i + markdownString.substr(i).toLowerCase().indexOf(closingTag);
+                if (indexOfClosingTag === -1) {
+                    // tag is never closed, so ignore the rest of the string
+                    i = markdownString.length;
+                } else {
+                    i = indexOfClosingTag + closingTag.length - 1;
+                }
+            } else {
+                result += '<' + lastTag + char;
+            }
+            lastTag = '';
+        } else {
+            if (inOpeningTag) {
+                lastTag += char;
+            } else {
+                result += char;
+            }
+        }
+    }
+
+    return result;
+}
+
 module.exports = {
     randid,
     validid,
+    sanitizeDangerousHtml,
 }
 


### PR DESCRIPTION
Add a check to attempt to sanitize notes that contain certain dangerous HTML tags.

This isn't a perfect sanitizer. Notably, it fails to correctly parse more nuanced HTML, like:

```html
<script>console.log('hi </script>');</script>
```

... which the sanitizer will convert to `');</script>`, because it thinks the first occurrence of `</script>` is closing the tag, when it's a part of JS. But I'm not sure how to get around these edge cases without creating a full-blown parser for HTML/JS/CSS syntax.

On the bright side, the algorithm in the PR errs on the safe side and mangles these dangerous tags even if the sanitization result is not perfect, since all dangerous opening tags are removed, even if they're potentially closed early. So I feel ok with the imperfect algorithm, since I don't really care if dangerous HTML is rendered beautifully.

I also considered using third party HTML sanitizers, like [sanitize-html](https://www.npmjs.com/package/sanitize-html), but even most other lightweight sanitizers seem to fail on the above example. This would be a good thing to add unit tests for, so I might do that if I get some time....

This PR aims to resolve #2.